### PR TITLE
Refactoring Service Provider to use the boot() method which works for both Laravel and Lumen

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ composer update
 ```
 
 ## Configuration
-Add the ServiceProvider to your `providers` array in `app/config/app.php`:
+Add the ServiceProvider to your `providers` array in `config/app.php`:
 
 	'Squigg\AzureQueueLaravel\AzureQueueServiceProvider',
 
-add the following to the `connection` array in `app/config/queue.php`, set your `default` connection to `azure` and
+add the following to the `connection` array in `config/queue.php`, set your `default` connection to `azure` and
 fill out your own connection data from the Azure Management portal:
 
 	'azure' => [

--- a/src/AzureQueueServiceProvider.php
+++ b/src/AzureQueueServiceProvider.php
@@ -3,25 +3,24 @@
 namespace Squigg\AzureQueueLaravel;
 
 use Illuminate\Queue\QueueManager;
+use Illuminate\Support\ServiceProvider;
 
-class AzureQueueServiceProvider extends \Illuminate\Support\ServiceProvider
+class AzureQueueServiceProvider extends ServiceProvider
 {
 
     /**
-     * Register the service provider.
+     * Bootstrap any application services.
      *
      * @return void
      */
-    public function register()
+    public function boot()
     {
-        $this->app->booted(function () {
+        /** @var QueueManager $manager */
+        $manager = $this->app['queue'];
 
-            /** @var QueueManager $manager */
-            $manager = $this->app['queue'];
-
-            $manager->addConnector('azure', function () {
-                return new AzureConnector;
-            });
+        $manager->addConnector('azure', function () {
+            return new AzureConnector;
         });
     }
+
 }


### PR DESCRIPTION
I am running Lumen, and when I try to use this service provider, the error I get is `Call to undefined method MyAppNamespace\Application::booted()`. This is occurring because booted() does not exist on `\Laravel\Lumen\Application`. Additionally, we should not need to register the listener as the service provider has a `boot()` method.

Thus, this PR uses the boot method for loading the new queue connector. I have tested it manually and verified it works on both Lumen and Laravel. Once this is merged in, it should be backported to 5.3 and 5.2 branches - I would have done so but not sure what your recommended practice is on this.

Besides the service provider update, this also fixes a small typo in the documentation which still references config files within the `app` directory.

Thanks!