### PR TITLE
Implementing the register method in the service provider for compatibility with Laravel/Lumen 5.2

### DIFF
--- a/src/AzureQueueServiceProvider.php
+++ b/src/AzureQueueServiceProvider.php
@@ -9,6 +9,15 @@ class AzureQueueServiceProvider extends ServiceProvider
 {
 
     /**
+     * Register bindings in the container.
+     *
+     * @return void
+     */
+    public function register()
+    {
+    }
+
+    /**
      * Bootstrap any application services.
      *
      * @return void


### PR DESCRIPTION
This is an update to #2 - I was just testing the package on Lumen 5.2, and got the error `Class Squigg\AzureQueueLaravel\AzureQueueServiceProvider contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Illuminate\Support\ServiceProvider::register)`

Apparently `register()` was made non-abstract for 5.3: https://github.com/laravel/framework/commit/56b52c2e94f211bb04c52e8f1971432969784bab - because of that, the service provider update doesn't work on 5.2. Had to add it back to the service provider for it to work.

Sorry I didn't catch this in my original PR! Hopefully this can get in before backporting.