### PR TITLE
Added base64 encription to messages

### DIFF
--- a/src/AzureQueue.php
+++ b/src/AzureQueue.php
@@ -73,7 +73,11 @@ class AzureQueue extends Queue implements QueueInterface
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
-        $this->azure->createMessage($this->getQueue($queue), $payload);
+        if(env(AZURE_BASE64_ENCODE)) {
+            $this->azure->createMessage($this->getQueue($queue), base64_encode($payload));
+        } else {
+            $this->azure->createMessage($this->getQueue($queue), $payload);
+        }
     }
 
     /**

--- a/src/AzureQueue.php
+++ b/src/AzureQueue.php
@@ -73,7 +73,7 @@ class AzureQueue extends Queue implements QueueInterface
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
-        if(env(AZURE_BASE64_ENCODE)) {
+        if(env('AZURE_BASE64_ENCODE')) {
             $this->azure->createMessage($this->getQueue($queue), base64_encode($payload));
         } else {
             $this->azure->createMessage($this->getQueue($queue), $payload);


### PR DESCRIPTION
This PR fixes the problem with Azure trying to read messages in the queue that are not base64 encoded.

The error is:
`The input is not a balid Base-64 string as it contains a non-base 64 character, more than two padding characters, or an illegal character among the padding characters.`