### PR TITLE
[#18] Support PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - '7.3'
   - '7.4'
+  - '8.0'
 
 install:
   - travis_retry composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": "^7.3",
+    "php": "^7.3|^8.0",
     "illuminate/queue": "^8.0",
     "microsoft/azure-storage-queue": "~1.3.0"
   },


### PR DESCRIPTION
Adds support for PHP 8. No dependencies needed updating and all tests continued to pass.

Resolves #18 