### PR TITLE
Adds support for QueueEndpoint parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ fill out your own connection data from the Azure Management portal:
         'queue'         => env('AZURE_QUEUE_NAME'),             // Queue container name
         'timeout'       => 60,                                  // Seconds before a job is released back to the queue
         'endpoint'      => env('AZURE_QUEUE_ENDPOINTSUFFIX'),   // Optional endpoint suffix if different from core.windows.net
+        'queue_endpoint'=> env('AZURE_QUEUE_ENDPOINT'),         // Optional endpoint for custom addresses like http://localhost/my_storage_name
     ],
 
 Add environment variables into your `.env` file to set the above configuration parameters:
@@ -106,6 +107,7 @@ Add environment variables into your `.env` file to set the above configuration p
     AZURE_QUEUE_KEY=xxx
     AZURE_QUEUE_NAME=xxx
     AZURE_QUEUE_ENDPOINTSUFFIX=xxx
+    AZURE_QUEUE_ENDPOINT=xxx
     
 #### Set the default Laravel queue
 Update the default queue used by Laravel by setting the `QUEUE_CONNECTION` value in your `.env` file to `azure`.

--- a/src/AzureConnector.php
+++ b/src/AzureConnector.php
@@ -23,6 +23,10 @@ class AzureConnector implements ConnectorInterface
             $connectionString .= ";EndpointSuffix=" . $config['endpoint'];
         }
 
+        if (isset($config['queue_endpoint']) && $config['queue_endpoint'] !== "") {
+            $connectionString .= ";QueueEndpoint=" . $config['queue_endpoint'];
+        }
+
         $queueRestProxy = QueueRestProxy::createQueueService($connectionString);
 
         return new AzureQueue($queueRestProxy, $config['queue'], $config['timeout']);

--- a/tests/AzureConnectorTest.php
+++ b/tests/AzureConnectorTest.php
@@ -62,4 +62,16 @@ class AzureConnectorTest extends TestCase
         $this->connector->connect($this->config);
     }
 
+    /** @test */
+    public function it_can_create_azure_queue_with_queue_endpoint()
+    {
+        $this->config['queue_endpoint'] = 'http://localhost:10001/test';
+
+        $connectionString = 'DefaultEndpointsProtocol=https;AccountName=foo;AccountKey=bar;QueueEndpoint=http://localhost:10001/test';
+        $queueProxy = Mockery::mock(IQueue::class);
+        $this->queueRestProxy->shouldReceive('createQueueService')->once()->with($connectionString)->andReturn($queueProxy);
+
+        /** @var AzureQueue $azureQueue */
+        $this->connector->connect($this->config);
+    }
 }


### PR DESCRIPTION
As discussed in the recent [issue item](https://github.com/squigg/azure-queue-laravel/issues/21), the goal of the PR is to add support of **QueueEndpoint** parameter to the connector. It would allow the usage of some more unusual configurations 🙂