### PR TITLE
fix return type for getJobId to be string

### DIFF
--- a/src/AzureJob.php
+++ b/src/AzureJob.php
@@ -105,7 +105,7 @@ class AzureJob extends Job implements JobContract
     /**
      * Get the job ID
      */
-    public function getJobId(): int
+    public function getJobId(): string
     {
         return $this->job->getMessageId();
     }


### PR DESCRIPTION
AzureJob.php contains a wrong return type of int instead of string for `getJobId()`